### PR TITLE
fix: Fix `index.ts` module exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
-import * as BN from './BigNumber';
-export default BN;
+export * from './BigNumber';
+
+import BN from './BigNumber';
+module.exports = BN;


### PR DESCRIPTION
So the current way we export the BN class breaks TypeScript when using the lib as a normal module.

```ts
import bn from './BigNumber'
module.exports = bn
```

The way I'd do it would be to just forward the export;

```ts
export * from './BigNumber'
```

...but I think you tested that and it didn't work for you, right @Szymon20000?

If that's the case, does this change maybe work?

```ts
import * as BN from './BigNumber'
export default BN
```