### PR TITLE
Fix: Ensure correct hexadecimal representation for .toString('hex') and .toString(16) methods

### DIFF
--- a/cpp/MGBigNumberHostObject.cpp
+++ b/cpp/MGBigNumberHostObject.cpp
@@ -333,9 +333,16 @@ namespace margelo
             std::shared_ptr<MGBigNumber> thiz = thisValue.getObject(runtime).getHostObject<MGBigNumber>(runtime);
 
             int base = 10;
-            if (!arguments[0].isUndefined() && arguments[0].isNumber())
-            {
-                base = (int)arguments[0].asNumber();
+            if (!arguments[0].isUndefined()) {
+                if (arguments[0].isNumber()) {
+                    base = static_cast<int>(arguments[0].asNumber());
+                } else if (arguments[0].isString()) {
+                    std::string argValue = arguments[0].getString(runtime).utf8(runtime);
+                    if (argValue == "hex") {
+                        base = 16;
+                    }
+                    // TODO: Add more conditions here if you support other string representations for bases.
+                }
             }
             int len = -1;
             if (!arguments[1].isUndefined())

--- a/example/src/Testing/bn-tests/constructor-test.js
+++ b/example/src/Testing/bn-tests/constructor-test.js
@@ -38,6 +38,11 @@ export function registerConstructorTests() {
       it('should accept two-limb LE number', function () {
         assert.equal(new BN(0x4123456, null, 'le').toString(16), '56341204');
       });
+
+      it('should correctly convert number to hexadecimal', function () {
+        assert.equal(new BN(100).toString('hex'), '64');
+        assert.equal(new BN(100).toString(16), '64');
+      });
     });
 
     describe('with String input', function () {


### PR DESCRIPTION
Fixes #60

### Root Cause

The original implementation of the toString method was designed to only handle numerical base representations. When a string-based representation like `'hex'` was passed to the method, it was not recognized or processed, and the method defaulted to returning the decimal string representation of the number (`base = 10`)

### Summary:

- Enhanced the toString method to correctly handle string-based base representations, ensuring that `.toString('hex')` and `.toString(16)` return the expected hexadecimal format of the number.
- Added a test case to validate the correct conversion of numbers to hexadecimal.