### PR TITLE
android: default to `minSdkVersion 23` instead of forcing `21`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
       externalNativeBuild {
       cmake {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,5 +2,6 @@ BigNumber_compileSdkVersion=30
 BigNumber_buildToolsVersion=30.0.2
 BigNumber_targetSdkVersion=30
 BigNumber_ndkVersion=21.4.7075529
+BigNumber_minSdkVersion=23
 android.useAndroidX=true
 


### PR DESCRIPTION
This PR updates the `minSdkVersion` to default to 23 instead of forcing 21 because React Native 0.74 bumped it to 23: https://github.com/react-native-community/discussions-and-proposals/discussions/740. 