### PR TITLE
bumps openssl to 3.3.2 from 1.11.11-beta-1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,8 +125,8 @@ repositories {
 }
 
 dependencies {
-  // https://mvnrepository.com/artifact/com.android.ndk.thirdparty/openssl
-  implementation 'com.android.ndk.thirdparty:openssl:1.1.1l-beta-1'
+  // Add a dependency on OpenSSL
+  implementation "io.github.ronickg:openssl:3.3.2"
 
   implementation "com.facebook.react:react-android:0.71.6"
   implementation "com.facebook.react:hermes-android:0.71.6"


### PR DESCRIPTION
Bumps OpenSSL to the same version quick-crypto has. Not sure if this is possible yet to be honest but wanted to get the ball rolling.

Fixes issue when using both libraries.

Thanks!



❯ nm -D node_modules/react-native-quick-crypto/../libcrypto.so | rg BN_CTX_new
000000000026a3b0 T BN_CTX_new@@OPENSSL_3.0.0
000000000026a36c T BN_CTX_new_ex@@OPENSSL_3.0.0

❯ nm -D node_modules/react-native-bignumber/../libcrypto.so | rg BN_CTX_new
00000000000aeac0 T BN_CTX_new@@OPENSSL_1_1_0