### PR TITLE
fix(toArrayLike): ensure minimum array length in BigNumber for zero length buffers

### DIFF
--- a/src/BigNumber.ts
+++ b/src/BigNumber.ts
@@ -240,7 +240,8 @@ export class BN {
       return this.toArray(endian, len);
     }
 
-    const outLen = len != null ? len : this.byteLength();
+    // Ensure minimum array length of 1 to prevent native crashes with zero-length buffers
+    const outLen = len != null ? len : Math.max(1, this.byteLength());
 
     const res = new (arrayLike as any)(outLen);
 


### PR DESCRIPTION
## Summary

This PR closes #80. We have currently added a patch for the same & it seems to be working as expected in our testing.

This is my first PR on this project, so let me know I should update my PR with anything more.

## Why This Fix Works

1. **Prevents 0-length buffers**: `Math.max(1, this.byteLength())` ensures minimum 1-byte buffer
2. **Maintains compatibility**: For non-zero values, behavior is identical
3. **Aligns with standard**: Matches `bn.js` behavior for consistency - https://github.com/indutny/bn.js/blob/6db7c3818569423b94ebcf2bdff90fcfb9c47f6d/lib/bn.js#L577